### PR TITLE
chore: jx-quickstart-go-app to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.118
 - name: jx-quickstart-go-app
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.3


### PR DESCRIPTION
chore: Promote jx-quickstart-go-app to version 0.0.3